### PR TITLE
GH-2 Optimize isIndex

### DIFF
--- a/src/main/java/com/github/subalakr/yasjl/JsonPointerTree.java
+++ b/src/main/java/com/github/subalakr/yasjl/JsonPointerTree.java
@@ -131,13 +131,13 @@ public class JsonPointerTree {
             return child;
         }
 
-        private boolean isIndex(String value) {
-            try {
-                Integer.parseInt(value);
-                return true;
-            } catch (NumberFormatException ex) {
-                return false;
+        boolean isIndex(String s) {
+            int len = s.length();
+            for (int a = 0; a < len; a++) {
+                if (a == 0 && s.charAt(a) == '-') continue;
+                if (!Character.isDigit(s.charAt(a))) return false;
             }
+            return true;
         }
 
         public Node match(String value) {


### PR DESCRIPTION
Instead of using parseInt with radix, directly use isDigit and verify if
it is a numerical value, this brings down the sample count from 10K to 4K.